### PR TITLE
Fixed Windows paths

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jdk.version>1.5</jdk.version>
+    <jdk.version>1.6</jdk.version>
     <commons-compress-version>1.8.1</commons-compress-version>
     <commons-io-version>2.4</commons-io-version>
   </properties>
@@ -111,11 +111,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.10</version>
+        <version>3.1.0</version>
         <configuration>
           <nocomment>true</nocomment>
           <useDefaultManifestFile>true</useDefaultManifestFile>
-          <additionalparam>-Xdoclint:none</additionalparam>
+          <!--<additionalparam>-Xdoclint:none</additionalparam>-->
+		  <additionalJOption>-Xdoclint:none</additionalJOption>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/github/phuonghuynh/compressor/Compressor.java
+++ b/src/main/java/com/github/phuonghuynh/compressor/Compressor.java
@@ -69,7 +69,13 @@ public class Compressor extends AbstractMojo {
          for (File file : files) {
             String fullpath = file.getCanonicalPath();
             getLog().info(String.format("Processing file %s", fullpath));
-            File zFile = new File(outputDirectory + "/" + file.getCanonicalPath().replaceFirst(workingDirectory, "")
+			if(System.getProperty("os.name").contains("Windows")) {
+				getLog().info("OS is Windows-based, altering path strings to use Java-compatible path separators");
+				workingDirectory = workingDirectory.replace("\\", "/");
+				fullpath = fullpath.replace("\\", "/");
+			}
+			
+            File zFile = new File(outputDirectory + "/" + fullpath.replaceFirst(workingDirectory, "")
                   + "." + outputExt);
             zFile.getParentFile().mkdirs();
             GzipCompressorOutputStream gzip = new GzipCompressorOutputStream(new FileOutputStream(zFile));


### PR DESCRIPTION
Adding in a full Windows path ("C:\Folder\AnotherFolder...") as a `workingDirectory` or an `outputDirectory` was not working, so I added a small check to allow "\\" characters to be replaced with "/" when Windows is detected as the OS and thus make those paths Java-compatible.

Separately, both the Java version (1.5) and the Maven Javadoc plugin (2.10) were not compatible with JDK 8+ and Maven 3.3.9, so I've updated the POM to Java 1.6 and Maven Javadoc 3.1.0.